### PR TITLE
Fix bug in drivetrain pose reset during simulation

### DIFF
--- a/SoftwareBot/src/main/java/frc/robot/RobotContainer.java
+++ b/SoftwareBot/src/main/java/frc/robot/RobotContainer.java
@@ -13,6 +13,7 @@ import com.pathplanner.lib.auto.PIDConstants;
 import com.pathplanner.lib.auto.SwerveAutoBuilder;
 
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
@@ -114,7 +115,7 @@ public class RobotContainer {
 
         // Button to reset the robot's pose to a default starting point.  Handy when running in the simulator and 
         // you accidently lose the robot outside the game field, should NOT be configured in the competition bot.
-        driverController.start().onTrue(new InstantCommand(() -> drivetrainSubsystem.resetPose(new Pose2d())));
+        driverController.start().onTrue(new InstantCommand(() -> drivetrainSubsystem.resetPose(new Pose2d(8.0, 3.0, new Rotation2d(0.0)))));
 
         driverController.a().whileTrue(swerveTestCommand);
     }

--- a/SoftwareBot/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSubsystem.java
+++ b/SoftwareBot/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainSubsystem.java
@@ -6,6 +6,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.*;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Robot;
 import frc.robot.sim.SimModelData;
 
 import org.littletonrobotics.junction.Logger;
@@ -108,7 +109,12 @@ public class DrivetrainSubsystem extends SubsystemBase {
     }
 
     public void resetPose (Pose2d newPose) {
-        odometry.resetPosition(new Rotation2d(gyroInputs.yawRadians), modulePositions, newPose);
+        if (Robot.isReal()) {
+            odometry.resetPosition(new Rotation2d(gyroInputs.yawRadians), modulePositions, newPose);
+        } else {
+            // If we are running in the simulator make sure the pose and gyro rotation values are the same.
+            odometry.resetPosition(newPose.getRotation(), modulePositions, newPose);
+        }
     }
 
     public double getMaxTranslationalVelocityMetersPerSecond() {


### PR DESCRIPTION
The drivetrain's reset pose operation during simulation causes the robot to spin out of control because the new pose is based on the yaw value from the gryo which, during sim, is in turn derived from the pose.